### PR TITLE
feat: add separate video and audio URLs muxing

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,9 @@ zeroplay https://example.com/stream.m3u8
 # Play an HLS stream, cap at 2 Mbps (useful on Pi Zero)
 zeroplay --hls-bitrate 2000000 https://example.com/stream.m3u8
 
+# Play video combined from separate video (no audio) and audio HLS streams (like YouTube does)
+zeroplay (https://example.com/stream_video.m3u8)(https://example.com/stream_audio.m3u8)
+
 # Play all media in a directory
 zeroplay /home/pi/media/
 

--- a/src/audio.c
+++ b/src/audio.c
@@ -433,8 +433,18 @@ void audio_run(AudioContext *ctx)
             pthread_cond_wait(&ctx->pause_cond, &ctx->pause_mutex);
         pthread_mutex_unlock(&ctx->pause_mutex);
 
-        /* Pull next packet from queue */
         void *item = NULL;
+
+        /* If queue is closed free all items */
+        if (ctx->audio_queue->closed) {
+            while (!queue_pop(ctx->audio_queue, &item)) {
+                AVPacket *pkt = (AVPacket *)item;
+                av_packet_free(&pkt);
+            }
+            break;
+        }
+
+        /* Pull next packet from queue */
         if (!queue_pop(ctx->audio_queue, &item))
             break;       /* queue closed — EOS */
 

--- a/src/audio.c
+++ b/src/audio.c
@@ -29,6 +29,9 @@
 #  define HAVE_CH_LAYOUT 0
 #endif
 
+#define VIDEO_AUDIO_DESYNC_THRESHOLD 0.5
+#define VIDEO_AUDIO_DESYNC_EPSILON   0.01
+
 static int get_channels(AVCodecParameters *par)
 {
 #if HAVE_CH_LAYOUT
@@ -242,6 +245,9 @@ int audio_open(AudioContext *ctx, AVStream *stream,
     ctx->volume         = 1.0f;
     ctx->muted          = 0;
 
+    ctx->video_pts      = NULL;
+    ctx->audio_pts      = 0;
+
     pthread_mutex_init(&ctx->pause_mutex, NULL);
     pthread_cond_init(&ctx->pause_cond, NULL);
 
@@ -434,6 +440,24 @@ void audio_run(AudioContext *ctx)
 
         /* Decode the packet.  Note: pkt is local — no leak. */
         AVPacket *pkt = (AVPacket *)item;
+
+        /* Block while ahead of video */
+        if (ctx->video_pts) {
+            int64_t audio_pts = pkt->pts;
+
+            double delta;
+            int first_iter = 1;
+            do {
+                delta = audio_pts * ctx->audio_time_base - *ctx->video_pts * ctx->video_time_base;
+
+                if (first_iter) {
+                    first_iter = 0;
+                    if (delta < VIDEO_AUDIO_DESYNC_THRESHOLD) break;
+                }
+            } while (!ctx->audio_queue->closed && (delta > VIDEO_AUDIO_DESYNC_EPSILON));
+
+            ctx->audio_pts = audio_pts;
+        }
 
         if (avcodec_send_packet(ctx->codec_ctx, pkt) < 0) {
             av_packet_free(&pkt);

--- a/src/audio.c
+++ b/src/audio.c
@@ -464,6 +464,8 @@ void audio_run(AudioContext *ctx)
                     first_iter = 0;
                     if (delta < VIDEO_AUDIO_DESYNC_THRESHOLD) break;
                 }
+
+                usleep(VIDEO_AUDIO_DESYNC_EPSILON * 1000000.0);
             } while (!ctx->audio_queue->closed && (delta > VIDEO_AUDIO_DESYNC_EPSILON));
 
             ctx->audio_pts = audio_pts;

--- a/src/audio.h
+++ b/src/audio.h
@@ -37,6 +37,12 @@ typedef struct {
     volatile int     paused;
     pthread_mutex_t  pause_mutex;
     pthread_cond_t   pause_cond;
+
+    /* Sync with video if separate */
+    volatile int64_t *video_pts;
+    int64_t           audio_pts;
+    double            video_time_base;
+    double            audio_time_base;
 } AudioContext;
 
 int       audio_open(AudioContext *ctx, AVStream *stream,

--- a/src/demux.c
+++ b/src/demux.c
@@ -6,7 +6,7 @@
 
 int demux_open(DemuxContext *ctx, const char *filename,
                Queue *video_queue, Queue *audio_queue,
-               int64_t hls_max_bandwidth)
+               int64_t hls_max_bandwidth, int separate_audio)
 {
     ctx->fmt_ctx             = NULL;
     ctx->video_stream_idx    = -1;
@@ -72,36 +72,53 @@ int demux_open(DemuxContext *ctx, const char *filename,
             ctx->subtitle_stream_idx = (int)i;
     }
 
-    /* Fallback: if no H.264 stream found, take the first video stream
-     * so we at least report the codec to the user. */
-    if (ctx->video_stream_idx == -1) {
-        for (unsigned int i = 0; i < ctx->fmt_ctx->nb_streams; i++) {
-            AVCodecParameters *par = ctx->fmt_ctx->streams[i]->codecpar;
-            if (par->codec_type == AVMEDIA_TYPE_VIDEO) {
-                ctx->video_stream_idx = (int)i;
-                fprintf(stderr, "demux: WARNING — no H.264 stream found, "
-                        "selected %s (may not decode on V4L2 M2M)\n",
-                        avcodec_get_name(par->codec_id));
-                break;
+    if (separate_audio) {
+        if (ctx->audio_stream_idx == -1) {
+            fprintf(stderr, "demux: no audio stream found\n");
+            return -1;
+        }
+        if (ctx->video_stream_idx != -1) {
+            fprintf(stderr, "demux: duplicate video stream found\n");
+            return -1;
+        }
+        if (ctx->subtitle_stream_idx != -1) {
+            fprintf(stderr, "demux: duplicate subtitle stream found\n");
+            return -1;
+        }
+    } else {
+        /* Fallback: if no H.264 stream found, take the first video stream
+        * so we at least report the codec to the user. */
+        if (ctx->video_stream_idx == -1) {
+            for (unsigned int i = 0; i < ctx->fmt_ctx->nb_streams; i++) {
+                AVCodecParameters *par = ctx->fmt_ctx->streams[i]->codecpar;
+                if (par->codec_type == AVMEDIA_TYPE_VIDEO) {
+                    ctx->video_stream_idx = (int)i;
+                    fprintf(stderr, "demux: WARNING — no H.264 stream found, "
+                            "selected %s (may not decode on V4L2 M2M)\n",
+                            avcodec_get_name(par->codec_id));
+                    break;
+                }
             }
         }
-    }
 
-    if (ctx->video_stream_idx == -1) {
-        fprintf(stderr, "demux: no video stream found\n");
-        return -1;
+        if (ctx->video_stream_idx == -1) {
+            fprintf(stderr, "demux: no video stream found\n");
+            return -1;
+        }
     }
 
     /* Duration in microseconds */
     if (ctx->fmt_ctx->duration != AV_NOPTS_VALUE)
         ctx->duration_us = ctx->fmt_ctx->duration;   /* AV_TIME_BASE = 1us */
 
-    AVStream *vs = ctx->fmt_ctx->streams[ctx->video_stream_idx];
-    vlog("demux: video stream %d — %s %dx%d @ %d/%d fps\n",
-            ctx->video_stream_idx,
-            avcodec_get_name(vs->codecpar->codec_id),
-            vs->codecpar->width, vs->codecpar->height,
-            vs->avg_frame_rate.num, vs->avg_frame_rate.den);
+    if (ctx->video_stream_idx >= 0) {
+        AVStream *vs = ctx->fmt_ctx->streams[ctx->video_stream_idx];
+        vlog("demux: video stream %d — %s %dx%d @ %d/%d fps\n",
+                ctx->video_stream_idx,
+                avcodec_get_name(vs->codecpar->codec_id),
+                vs->codecpar->width, vs->codecpar->height,
+                vs->avg_frame_rate.num, vs->avg_frame_rate.den);
+    }
 
     if (ctx->audio_stream_idx >= 0) {
         AVStream *as = ctx->fmt_ctx->streams[ctx->audio_stream_idx];
@@ -180,7 +197,8 @@ void demux_run(DemuxContext *ctx)
 
     av_packet_free(&pkt);
 done:
-    queue_close(ctx->video_queue);
+    if (ctx->video_stream_idx >= 0)
+        queue_close(ctx->video_queue);
     if (ctx->audio_stream_idx >= 0)
         queue_close(ctx->audio_queue);
     if (ctx->subtitle_stream_idx >= 0 && ctx->subtitle_queue)

--- a/src/demux.h
+++ b/src/demux.h
@@ -17,7 +17,7 @@ typedef struct {
 
 int  demux_open(DemuxContext *ctx, const char *filename,
                 Queue *video_queue, Queue *audio_queue,
-                int64_t hls_max_bandwidth);
+                int64_t hls_max_bandwidth, int separate_audio);
 void demux_run(DemuxContext *ctx);
 int  demux_seek(DemuxContext *ctx, int64_t target_us);
 int  demux_next_chapter(DemuxContext *ctx, int64_t current_us, int64_t *target_us);

--- a/src/main.c
+++ b/src/main.c
@@ -393,8 +393,10 @@ static void player_threads_stop(PlayerContext *p)
     if (p->audio_active && p->separate_audio)
         pthread_join(p->datid, NULL);
     pthread_join(p->vtid, NULL);
-    if (p->audio_active)
+    if (p->audio_active) {
+        audio_resume(&p->audio);
         pthread_join(p->atid, NULL);
+    }
     if (p->sub_active && p->sub_embedded)
         pthread_join(p->stid, NULL);
 }

--- a/src/main.c
+++ b/src/main.c
@@ -179,6 +179,32 @@ static int parse_args(int argc, char *argv[], Options *opt)
     return 0;
 }
 
+/* Parse URL of type: "(video_url)(audio_url)" */
+static void parse_separated_video_audio_url(const char *url, char *url_video, char *url_audio)
+{
+    if (url[0] != '(') {
+        strncpy(url_video, url, PLAYLIST_ITEM_PATH_SIZE - 1);
+        url_audio[0] = '\0';
+        return;
+    }
+
+    const char *url_video_open = url;
+    const char *url_video_close = strchr(url, ')');
+    if (!url_video_close) return;
+
+    const char *url_audio_open = url_video_close + 1;
+    const char *url_audio_close = strrchr(url, ')');
+    if (url_audio_close == url_video_close) return;
+
+    const size_t url_video_size = url_video_close - url_video_open - 1;
+    strncpy(url_video, url_video_open + 1, url_video_size);
+    url_video[url_video_size] = '\0';
+
+    const size_t url_audio_size = url_audio_close - url_video_close - 2;
+    strncpy(url_audio, url_audio_open + 1, url_audio_size);
+    url_audio[url_audio_size] = '\0';
+}
+
 static struct termios orig_termios;
 
 static void term_restore(void)
@@ -272,12 +298,13 @@ static int find_srt_alongside(const char *video_path,
 typedef struct {
     Playlist     playlist;
     DemuxContext demux;
+    DemuxContext demux_audio; /* Separate demuxer for audio only to be able to combine separate video and audio inputs */
     VdecContext  vdec;
     AudioContext audio;
     Queue        video_queue;
     Queue        audio_queue;
     Queue        frame_queue;
-    pthread_t    dtid, vtid, atid;
+    pthread_t    dtid, datid, vtid, atid;
     int          pipeline_open;
     int          audio_active;
 
@@ -300,6 +327,7 @@ typedef struct {
 
     int          output_idx;
     int          no_audio;
+    int          separate_audio;
     int64_t      image_duration_us;
     int64_t      duration_us;
     DrmContext  *drm_ctx;      /* for subtitle overlay */
@@ -311,6 +339,11 @@ static void *demux_thread(void *arg)
 {
     PlayerContext *p = ((ThreadArg *)arg)->p; free(arg);
     demux_run(&p->demux); return NULL;
+}
+static void *demux_audio_thread(void *arg)
+{
+    PlayerContext *p = ((ThreadArg *)arg)->p; free(arg);
+    demux_run(&p->demux_audio); return NULL;
 }
 static void *vdec_thread(void *arg)
 {
@@ -331,8 +364,12 @@ static void *subtitle_thread(void *arg)
 static void player_threads_start(PlayerContext *p)
 {
     ThreadArg *da = malloc(sizeof(*da)); da->p = p;
-    ThreadArg *va = malloc(sizeof(*va)); va->p = p;
     pthread_create(&p->dtid, NULL, demux_thread, da);
+    if (p->audio_active && p->separate_audio) {
+        ThreadArg *daa = malloc(sizeof(*daa)); daa->p = p;
+        pthread_create(&p->datid, NULL, demux_audio_thread, daa);
+    }
+    ThreadArg *va = malloc(sizeof(*va)); va->p = p;
     pthread_create(&p->vtid, NULL, vdec_thread,  va);
     if (p->audio_active) {
         ThreadArg *aa = malloc(sizeof(*aa)); aa->p = p;
@@ -349,9 +386,12 @@ static void player_threads_stop(PlayerContext *p)
     queue_close(&p->video_queue);
     queue_close(&p->audio_queue);
     queue_close(&p->frame_queue);
+
     if (p->sub_active && p->sub_embedded)
         queue_close(&p->sub_queue);
     pthread_join(p->dtid, NULL);
+    if (p->audio_active && p->separate_audio)
+        pthread_join(p->datid, NULL);
     pthread_join(p->vtid, NULL);
     if (p->audio_active)
         pthread_join(p->atid, NULL);
@@ -404,6 +444,8 @@ static void player_close_pipeline(PlayerContext *p)
     }
     vdec_close(&p->vdec);
     demux_close(&p->demux);
+    if (p->audio_active && p->separate_audio)
+        demux_close(&p->demux_audio);
     queue_destroy(&p->video_queue);
     queue_destroy(&p->audio_queue);
     queue_destroy(&p->frame_queue);
@@ -416,19 +458,27 @@ static void player_close_pipeline(PlayerContext *p)
     p->eos           = 0;
 }
 
-static int player_open_video(PlayerContext *p, const char *filename,
+static int player_open_video(PlayerContext *p, const char *filename, const char *filename_audio,
                               const Options *opt)
 {
+    p->separate_audio = filename_audio[0] != '\0';
+
     queue_init(&p->video_queue);
     queue_init(&p->audio_queue);
     queue_init_size(&p->frame_queue, FRAME_QUEUE_SIZE);
 
     if (demux_open(&p->demux, filename, &p->video_queue, &p->audio_queue,
-                   opt->hls_max_bandwidth) < 0)
+                   opt->hls_max_bandwidth, 0) < 0)
         return -1;
 
-    if (p->no_audio)
+    if (!p->no_audio && p->separate_audio)
+        if (demux_open(&p->demux_audio, filename_audio, &p->video_queue, &p->audio_queue,
+                    opt->hls_max_bandwidth, 1) < 0)
+            return -1;
+
+    if (p->no_audio) {
         p->demux.audio_stream_idx = -1;
+    }
 
     AVStream *video_stream =
         p->demux.fmt_ctx->streams[p->demux.video_stream_idx];
@@ -437,11 +487,18 @@ static int player_open_video(PlayerContext *p, const char *filename,
         return -1;
 
     p->audio_active = 0;
-    if (!p->no_audio && p->demux.audio_stream_idx >= 0) {
-        AVStream *audio_stream =
-            p->demux.fmt_ctx->streams[p->demux.audio_stream_idx];
-        if (audio_open(&p->audio, audio_stream, opt->audio_device,
-                       &p->audio_queue) == 0) {
+    if (!p->no_audio) {
+        AVStream *audio_stream = NULL;
+        if (p->separate_audio && p->demux_audio.audio_stream_idx >= 0) {
+            audio_stream =
+                p->demux_audio.fmt_ctx->streams[p->demux_audio.audio_stream_idx];
+        } else if (p->demux.audio_stream_idx >= 0) {
+            audio_stream =
+                p->demux.fmt_ctx->streams[p->demux.audio_stream_idx];
+        }
+
+        if (audio_stream && (audio_open(&p->audio, audio_stream, opt->audio_device,
+                        &p->audio_queue) == 0)) {
             p->audio.volume = opt->vol / 100.0f;
             p->audio_active = 1;
         }
@@ -454,6 +511,8 @@ static int player_open_video(PlayerContext *p, const char *filename,
         int64_t start_us = (int64_t)(opt->start_pos * 1000000.0);
         if (start_us > p->duration_us) start_us = p->duration_us;
         demux_seek(&p->demux, start_us);
+        if (p->audio_active && p->separate_audio)
+            demux_seek(&p->demux_audio, start_us);
         p->current_pts = start_us;
     }
 
@@ -502,6 +561,8 @@ static void player_seek(PlayerContext *p, int64_t target_us)
 
     player_threads_stop(p);
     demux_seek(&p->demux, target_us);
+    if (p->audio_active && p->separate_audio)
+        demux_seek(&p->demux_audio, target_us);
     vdec_flush(&p->vdec);
     if (p->audio_active) audio_flush(&p->audio);
     if (p->sub_active)   subtitle_flush(&p->sub);
@@ -547,29 +608,30 @@ static int player_advance_to_next(PlayerContext *p, DrmContext *drm,
         player_close_pipeline(p);
         p->image_mode = 0;
 
-        if (player_open_video(p, item->path, opt) < 0) {
-            fprintf(stderr, "zeroplay[%d]: failed to open '%s', skipping\n",
-                    p->output_idx, item->path);
+        if (player_open_video(p, item->path, item->path_audio, opt) < 0) {
+            fprintf(stderr, "zeroplay[%d]: failed to open '%s' '%s', skipping\n",
+                    p->output_idx, item->path, item->path_audio);
             return player_advance_to_next(p, drm, opt);
         }
-        fprintf(stderr, "zeroplay[%d]: playing '%s'\n",
-                p->output_idx, basename(item->path));
+        fprintf(stderr, "zeroplay[%d]: playing '%s' '%s'\n",
+                p->output_idx, basename(item->path), basename(item->path_audio));
         player_threads_start(p);
     }
 
     return 0;
 }
 
-static int player_open(PlayerContext *p, const char *path,
+static int player_open(PlayerContext *p, const char *path, const char *path_audio,
                         const Options *opt, int output_idx, DrmContext *drm)
 {
     memset(p, 0, sizeof(*p));
     p->output_idx        = output_idx;
     p->no_audio          = opt->no_audio || (output_idx != 0);
+    p->separate_audio    = 0;
     p->image_duration_us = (int64_t)(opt->image_duration_s * 1000000.0);
     p->drm_ctx           = drm;
 
-    if (playlist_open(&p->playlist, path, opt->loop, opt->shuffle) < 0)
+    if (playlist_open(&p->playlist, path, path_audio, opt->loop, opt->shuffle) < 0)
         return -1;
 
     PlaylistItem *item = playlist_current(&p->playlist);
@@ -594,12 +656,12 @@ static int player_open(PlayerContext *p, const char *path,
                 output_idx, item->path,
                 (double)p->image_duration_us / 1e6);
     } else {
-        if (player_open_video(p, item->path, opt) < 0) {
+        if (player_open_video(p, item->path, item->path_audio, opt) < 0) {
             playlist_close(&p->playlist);
             return -1;
         }
-        fprintf(stderr, "zeroplay[%d]: playing '%s'\n",
-                output_idx, basename(item->path));
+        fprintf(stderr, "zeroplay[%d]: playing '%s' '%s'\n",
+                output_idx, basename(item->path), basename(item->path_audio));
     }
 
     return 0;
@@ -634,7 +696,7 @@ static void player_go_to_prev(PlayerContext *p, DrmContext *drm,
         fprintf(stderr, "zeroplay[%d]: showing '%s'\n",
                 p->output_idx, basename(item->path));
     } else {
-        if (player_open_video(p, item->path, opt) == 0)
+        if (player_open_video(p, item->path, item->path_audio, opt) == 0)
             player_threads_start(p);
     }
 }
@@ -706,7 +768,12 @@ static int run_ws_mode(Options *opt)
                 player_close_pipeline(&player);
                 paused = 0;
                 audio_started = 0;
-                if (player_open_video(&player, cmd.url, opt) < 0) {
+
+                char path[PLAYLIST_ITEM_PATH_SIZE];
+                char path_audio[PLAYLIST_ITEM_PATH_SIZE];
+                parse_separated_video_audio_url(cmd.url, path, path_audio);
+
+                if (player_open_video(&player, path, path_audio, opt) < 0) {
                     fprintf(stderr, "zeroplay: failed to open %s\n", cmd.url);
                     ws_shared_state_set_idle(&shared, 1);
                     ws_shared_state_set_url(&shared, NULL);
@@ -879,7 +946,11 @@ int main(int argc, char *argv[])
     PlayerContext players[MAX_FILES];
     int opened = 0;
     for (int i = 0; i < player_count; i++) {
-        if (player_open(&players[i], opt.paths[i], &opt, i, &drm) < 0) {
+        char path[PLAYLIST_ITEM_PATH_SIZE];
+        char path_audio[PLAYLIST_ITEM_PATH_SIZE];
+        parse_separated_video_audio_url(opt.paths[i], path, path_audio);
+
+        if (player_open(&players[i], path, path_audio, &opt, i, &drm) < 0) {
             fprintf(stderr, "zeroplay: failed to open '%s'\n", opt.paths[i]);
             for (int j = 0; j < opened; j++) player_shutdown(&players[j]);
             drm_close(&drm);

--- a/src/main.c
+++ b/src/main.c
@@ -1061,7 +1061,10 @@ int main(int argc, char *argv[])
                     : demux_prev_chapter(&players[i].demux,
                                          players[i].current_pts, &target);
                 if (found == 0) {
-                    int was_paused = paused; paused = 0;
+                    int was_paused = paused;
+                    paused = 0;
+                    if (was_paused)
+                        audio_resume(&players[i].audio);
                     player_seek(&players[i], target);
                     players[i].current_pts = target;
                     if (was_paused) {
@@ -1081,7 +1084,11 @@ int main(int argc, char *argv[])
             else if (key == KEY_UP)    delta = +SEEK_LONG_US;
             else if (key == KEY_DOWN)  delta = -SEEK_LONG_US;
 
-            int was_paused = paused; paused = 0;
+            int was_paused = paused;
+            paused = 0;
+            if (was_paused)
+                for (int i = 0; i < opened; i++)
+                    audio_resume(&players[i].audio);
             for (int i = 0; i < opened; i++) {
                 if (players[i].image_mode || !players[i].pipeline_open) continue;
                 int64_t target = players[i].current_pts + delta;

--- a/src/main.c
+++ b/src/main.c
@@ -501,6 +501,17 @@ static int player_open_video(PlayerContext *p, const char *filename, const char 
                         &p->audio_queue) == 0)) {
             p->audio.volume = opt->vol / 100.0f;
             p->audio_active = 1;
+
+            if (p->separate_audio)
+            {
+                p->vdec.audio_pts = &p->audio.audio_pts;
+                p->vdec.video_time_base = 1.0 / 1000000LL;
+                p->vdec.audio_time_base = av_q2d(p->demux_audio.fmt_ctx->streams[p->demux_audio.audio_stream_idx]->time_base);
+
+                p->audio.video_pts = &p->current_pts;
+                p->audio.video_time_base = 1.0 / 1000000LL;
+                p->audio.audio_time_base = av_q2d(p->demux_audio.fmt_ctx->streams[p->demux_audio.audio_stream_idx]->time_base);
+            }
         }
     }
 

--- a/src/playlist.c
+++ b/src/playlist.c
@@ -118,7 +118,7 @@ static void shuffle_items(Playlist *pl)
 /* Public API                                                           */
 /* ------------------------------------------------------------------ */
 
-int playlist_open(Playlist *pl, const char *path, int loop, int shuffle)
+int playlist_open(Playlist *pl, const char *path, const char *path_audio, int loop, int shuffle)
 {
     memset(pl, 0, sizeof(*pl));
     pl->loop    = loop;
@@ -142,6 +142,7 @@ int playlist_open(Playlist *pl, const char *path, int loop, int shuffle)
         }
         PlaylistItem *item = &pl->items[pl->count++];
         strncpy(item->path, path, sizeof(item->path) - 1);
+        strncpy(item->path_audio, path_audio, sizeof(item->path_audio) - 1);
         item->type = ITEM_VIDEO;
     } else {
         struct stat st;

--- a/src/playlist.h
+++ b/src/playlist.h
@@ -1,6 +1,7 @@
 #pragma once
 
-#define PLAYLIST_MAX_ITEMS 1024
+#define PLAYLIST_MAX_ITEMS      1024
+#define PLAYLIST_ITEM_PATH_SIZE 2048
 
 typedef enum {
     ITEM_VIDEO,
@@ -9,7 +10,8 @@ typedef enum {
 } PlaylistItemType;
 
 typedef struct {
-    char             path[512];
+    char             path[PLAYLIST_ITEM_PATH_SIZE];
+    char             path_audio[PLAYLIST_ITEM_PATH_SIZE];
     PlaylistItemType type;
 } PlaylistItem;
 
@@ -29,7 +31,7 @@ typedef struct {
  *
  * Returns 0 on success, -1 on error.
  */
-int           playlist_open(Playlist *pl, const char *path, int loop, int shuffle);
+int           playlist_open(Playlist *pl, const char *path, const char *path_audio, int loop, int shuffle);
 void          playlist_close(Playlist *pl);
 
 /* Returns pointer to current item, or NULL if empty. */

--- a/src/subtitle.c
+++ b/src/subtitle.c
@@ -162,6 +162,16 @@ void subtitle_run(SubtitleContext *ctx)
 
     while (1) {
         void *item = NULL;
+
+        /* If queue is closed free all items */
+        if (ctx->subtitle_queue->closed) {
+            while (!queue_pop(ctx->subtitle_queue, &item)) {
+                AVPacket *pkt = (AVPacket *)item;
+                av_packet_free(&pkt);
+            }
+            break;
+        }
+
         if (!queue_pop(ctx->subtitle_queue, &item))
             break;  /* queue closed — EOS */
 

--- a/src/vdec.c
+++ b/src/vdec.c
@@ -485,6 +485,16 @@ void vdec_run(VdecContext *ctx)
                 if (!out_buf_free[i]) continue;
 
                 void *item = NULL;
+
+                /* If queue is closed free all items */
+                if (ctx->packet_queue->closed) {
+                    while (!queue_pop(ctx->packet_queue, &item)) {
+                        AVPacket *pkt = (AVPacket *)item;
+                        av_packet_free(&pkt);
+                    }
+                    break;
+                }
+
                 if (!queue_pop(ctx->packet_queue, &item)) {
                     eos = 1;
                     break;

--- a/src/vdec.c
+++ b/src/vdec.c
@@ -14,6 +14,9 @@
 #include <libavutil/avutil.h>
 #include <libavutil/mathematics.h>
 
+#define VIDEO_AUDIO_DESYNC_THRESHOLD 0.5
+#define VIDEO_AUDIO_DESYNC_EPSILON   0.01
+
 /* ------------------------------------------------------------------ */
 /* Internal helpers                                                     */
 /* ------------------------------------------------------------------ */
@@ -286,6 +289,8 @@ int vdec_open(VdecContext *ctx, AVStream *stream,
 
     for (int i = 0; i < VDEC_CAPTURE_BUFS; i++)
         ctx->cap_dmabuf_fd[i] = -1;
+
+    ctx->audio_pts     = NULL;
 
     /* Map codec to V4L2 pixel format and select appropriate BSF */
     enum AVCodecID codec_id = stream->codecpar->codec_id;
@@ -567,6 +572,22 @@ void vdec_run(VdecContext *ctx)
                 frame->sar_den    = ctx->sar_den;
                 frame->pts_us     = (int64_t)buf.timestamp.tv_sec  * 1000000LL
                                   + (int64_t)buf.timestamp.tv_usec;
+
+                /* Block while ahead of audio */
+                if (ctx->audio_pts) {
+                    int64_t video_pts = frame->pts_us;
+
+                    double delta;
+                    int first_iter = 1;
+                    do {
+                        delta = -(*ctx->audio_pts * ctx->audio_time_base - video_pts * ctx->video_time_base);
+
+                        if (first_iter) {
+                            first_iter = 0;
+                            if (delta < VIDEO_AUDIO_DESYNC_THRESHOLD) break;
+                        }
+                    } while (!ctx->packet_queue->closed && (delta > VIDEO_AUDIO_DESYNC_EPSILON));
+                }
 
                 if (!queue_push(ctx->frame_queue, frame)) {
                     free(frame);

--- a/src/vdec.c
+++ b/src/vdec.c
@@ -596,6 +596,8 @@ void vdec_run(VdecContext *ctx)
                             first_iter = 0;
                             if (delta < VIDEO_AUDIO_DESYNC_THRESHOLD) break;
                         }
+
+                        usleep(VIDEO_AUDIO_DESYNC_EPSILON * 1000000.0);
                     } while (!ctx->packet_queue->closed && (delta > VIDEO_AUDIO_DESYNC_EPSILON));
                 }
 

--- a/src/vdec.h
+++ b/src/vdec.h
@@ -48,6 +48,11 @@ typedef struct {
     int             cap_dmabuf_fd[VDEC_CAPTURE_BUFS];
 
     int             fmt_negotiated;
+
+    /* Sync with audio if separate */
+    volatile int64_t *audio_pts;
+    double            video_time_base;
+    double            audio_time_base;
 } VdecContext;
 
 int  vdec_open(VdecContext *ctx, AVStream *stream,

--- a/src/ws.c
+++ b/src/ws.c
@@ -294,7 +294,7 @@ static void ws_send_state(WsContext *ctx)
     WsSharedState *s = ctx->shared_state;
     double pos;
     int paused, idle;
-    char url[2048];
+    char url[WS_COMMAND_URL_SIZE];
 
     pthread_mutex_lock(&s->mutex);
     pos    = s->position_s;

--- a/src/ws.h
+++ b/src/ws.h
@@ -3,10 +3,13 @@
 
 #include <stdint.h>
 #include <pthread.h>
+#include "playlist.h"
 
 /* ------------------------------------------------------------------ */
 /* Command types (ws_thread → main_thread)                             */
 /* ------------------------------------------------------------------ */
+
+#define WS_COMMAND_URL_SIZE (PLAYLIST_ITEM_PATH_SIZE - 1) * 2 + 4 + 1
 
 typedef enum {
     CMD_NONE = 0,
@@ -19,8 +22,8 @@ typedef enum {
 
 typedef struct {
     CmdType  type;
-    char     url[2048];          /* CMD_LOAD: media URL */
-    int64_t  seek_position_ms;   /* CMD_SEEK: target in milliseconds */
+    char     url[WS_COMMAND_URL_SIZE];    /* CMD_LOAD: media URL */
+    int64_t  seek_position_ms;            /* CMD_SEEK: target in milliseconds */
 } WsCommand;
 
 /* ------------------------------------------------------------------ */
@@ -48,11 +51,11 @@ void ws_cmd_queue_destroy(WsCmdQueue *q);
 
 typedef struct {
     pthread_mutex_t mutex;
-    double          position_s;     /* playback position in seconds, -1 if unknown */
+    double          position_s;                    /* playback position in seconds, -1 if unknown */
     int             paused;
-    char            url[2048];      /* currently loaded URL, "" if idle */
-    int             idle;           /* 1 when no media is loaded */
-    int             player_ready;   /* 1 when V4L2 pipeline is initialized */
+    char            url[WS_COMMAND_URL_SIZE];      /* currently loaded URL, "" if idle */
+    int             idle;                          /* 1 when no media is loaded */
+    int             player_ready;                  /* 1 when V4L2 pipeline is initialized */
 } WsSharedState;
 
 void ws_shared_state_init(WsSharedState *s);


### PR DESCRIPTION
This adds an ability to mux video and audio from two separate URLs.
Now instead of a "SINGLE_URL" the next expression can be used: "(VIDEO_URL)(AUDIO_URL)".

This ability can be useful for YouTube and other media providers, that store their video and audio separately.
An example command to play YouTube video will look like this:
`mapfile -t u < <(yt-dlp -f "bv[ext=mp4][vcodec^=avc][height<=1080]+ba[ext=m4a]" --get-url "https://www.youtube.com/watch?v=YyZq_lEJZ2U"); zeroplay "(${u[0]})(${u[1]})"`
or
`yt-dlp -f "bv[ext=mp4][vcodec^=avc][height<=1080]+ba[ext=m4a]" --get-url "https://www.youtube.com/watch?v=YyZq_lEJZ2U" | { read -r v; read -r a; zeroplay "(${v})(${a})"; }`.
Make sure **yt-dlp** is up-to-date (use python package instead of system package manager's one).

Also fixes deadlock bug when seeking or exiting during pause.
Also improves program exit and video seek time.