### PR TITLE
feat: add --recursive option to play all media from a folder recursively

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ Each path can be a video file, image, `.txt`/`.m3u` playlist, directory, URL, or
 |---|---|
 | `--loop` | Loop playback indefinitely |
 | `--shuffle` | Randomise playlist order |
+| `--recursive` | Load files from folder recursively |
 | `--no-audio` | Disable audio |
 | `--vol n` | Initial volume, 0–200 (default: 100) |
 | `--pos n` | Start position in seconds |
@@ -152,6 +153,9 @@ zeroplay --sub subtitles.srt movie.mp4
 
 # Play all media in a directory
 zeroplay /home/pi/media/
+
+# Play all media in a directory and its subdirectories
+zeroplay --recursive /home/pi/media/
 
 # Play a playlist file, loop and shuffle
 zeroplay --loop --shuffle playlist.txt

--- a/src/main.c
+++ b/src/main.c
@@ -46,6 +46,7 @@ typedef struct {
     const char *sub_path;
     float       image_duration_s;
     int         shuffle;
+    int         recurse;
     int         control;            /* --control: local stdin/stdout control mode */
 #ifdef HAVE_WEBSOCKET
     const char *ws_url;
@@ -69,6 +70,7 @@ static void print_usage(void)
         "options:\n"
         "  --loop                  loop playlist indefinitely\n"
         "  --shuffle               randomise playlist order\n"
+        "  --recursive             recurse into subdirectories when loading files from a folder\n"
         "  --no-audio              disable audio\n"
         "  --vol n                 initial volume 0-200 (default 100)\n"
         "  --pos n                 start position in seconds (video only)\n"
@@ -117,6 +119,7 @@ static int parse_args(int argc, char *argv[], Options *opt)
     static struct option long_opts[] = {
         { "loop",             no_argument,       NULL, 'l' },
         { "shuffle",          no_argument,       NULL, 'r' },
+        { "recursive",        no_argument,       NULL, 'R' },
         { "no-audio",         no_argument,       NULL, 'n' },
         { "vol",              required_argument, NULL, 'v' },
         { "pos",              required_argument, NULL, 'p' },
@@ -139,6 +142,7 @@ static int parse_args(int argc, char *argv[], Options *opt)
         switch (c) {
             case 'l': opt->loop              = 1;            break;
             case 'r': opt->shuffle           = 1;            break;
+            case 'R': opt->recurse           = 1;            break;
             case 'n': opt->no_audio          = 1;            break;
             case 'v': opt->vol               = atof(optarg); break;
             case 'p': opt->start_pos         = atof(optarg); break;
@@ -669,7 +673,7 @@ static int player_open(PlayerContext *p, const char *path,
     p->drm_ctx           = drm;
 
     if (playlist_open(&p->playlist, path, path_audio,
-                      opt->loop, opt->shuffle, opt->yt_quality) < 0)
+                      opt->loop, opt->shuffle, opt->recurse, opt->yt_quality) < 0)
         return -1;
 
     PlaylistItem *item = playlist_current(&p->playlist);

--- a/src/playlist.c
+++ b/src/playlist.c
@@ -4,6 +4,7 @@
 #include <strings.h>
 #include <sys/stat.h>
 #include <dirent.h>
+#include <limits.h>
 #include <time.h>
 #include "playlist.h"
 #include "log.h"
@@ -163,7 +164,7 @@ static int cmp_dirent(const struct dirent **a, const struct dirent **b)
     return strcasecmp((*a)->d_name, (*b)->d_name);
 }
 
-static int load_from_dir(Playlist *pl, const char *dirpath)
+static int load_from_dir(Playlist *pl, const char *dirpath, int recurse)
 {
     struct dirent **entries = NULL;
     int n = scandir(dirpath, &entries, NULL, cmp_dirent);
@@ -171,9 +172,12 @@ static int load_from_dir(Playlist *pl, const char *dirpath)
 
     for (int i = 0; i < n; i++) {
         if (entries[i]->d_name[0] != '.') {
-            char full[512];
+            char full[PATH_MAX];
             snprintf(full, sizeof(full), "%s/%s", dirpath, entries[i]->d_name);
-            add_item(pl, full);
+            if (recurse && entries[i]->d_type == DT_DIR)
+                load_from_dir(pl, full, recurse);
+            else
+                add_item(pl, full);
         }
         free(entries[i]);
     }
@@ -197,7 +201,7 @@ static void shuffle_items(Playlist *pl)
 /* ------------------------------------------------------------------ */
 
 int playlist_open(Playlist *pl, const char *path, const char *path_audio,
-                  int loop, int shuffle, int yt_quality)
+                  int loop, int shuffle, int recurse, int yt_quality)
 {
     memset(pl, 0, sizeof(*pl));
     pl->loop    = loop;
@@ -253,7 +257,7 @@ int playlist_open(Playlist *pl, const char *path, const char *path_audio,
         }
 
         if (S_ISDIR(st.st_mode))
-            load_from_dir(pl, path);
+            load_from_dir(pl, path, recurse);
         else if (is_playlist_file(path))
             load_from_txt(pl, path);
         else

--- a/src/playlist.h
+++ b/src/playlist.h
@@ -1,7 +1,9 @@
 #pragma once
 
+#include <limits.h>
+
 #define PLAYLIST_MAX_ITEMS      1024
-#define PLAYLIST_ITEM_PATH_SIZE 2048
+#define PLAYLIST_ITEM_PATH_SIZE PATH_MAX
 
 typedef enum {
     ITEM_VIDEO,
@@ -37,7 +39,7 @@ typedef struct {
  * Returns 0 on success, -1 on error.
  */
 int           playlist_open(Playlist *pl, const char *path, const char *path_audio,
-                             int loop, int shuffle, int yt_quality);
+                             int loop, int shuffle, int recurse, int yt_quality);
 void          playlist_close(Playlist *pl);
 
 /* Returns pointer to current item, or NULL if empty. */


### PR DESCRIPTION
Currently, when passing a directory as CLI argument, zeroplay only adds to the playlist the items directly in the folder passed as argument. The `--recursive` CLI option allows to discover all media in a directory tree recursively.