### PR TITLE
Bug fix: videos exiting early

### DIFF
--- a/src/demux.c
+++ b/src/demux.c
@@ -199,6 +199,8 @@ void demux_run(DemuxContext *ctx)
 
     while (av_read_frame(ctx->fmt_ctx, pkt) >= 0) {
         if (pkt->stream_index == ctx->video_stream_idx) {
+            pkt->pts == AV_NOPTS_VALUE ? -1.0
+            : pkt->pts * av_q2d(ctx->fmt_ctx->streams[ctx->video_stream_idx]->time_base);
             AVPacket *queued = av_packet_alloc();
             if (!queued) { av_packet_unref(pkt); continue; }
             av_packet_move_ref(queued, pkt);

--- a/src/main.c
+++ b/src/main.c
@@ -1201,7 +1201,30 @@ int main(int argc, char *argv[])
             }
         }
 
-        if (all_eos) break;
+        if (all_eos) {
+            /* Drain and display any remaining decoded frames before exiting */
+            for (int i = 0; i < opened; i++) {
+                PlayerContext *p = &players[i];
+                if (p->image_mode) continue;
+                while (1) {
+                    if (p->held_frame) {
+                        int64_t due = p->wall_start + p->held_frame->pts_us;
+                        int64_t now = now_us();
+                        if (due > now) sleep_us(due - now);
+                        drm_present(&drm, p->output_idx, p->held_frame);
+                        if (p->prev_frame)
+                            vdec_requeue_frame(&p->vdec, p->prev_frame);
+                        p->prev_frame  = p->held_frame;
+                        p->held_frame  = NULL;
+                    }
+                    void *item = NULL;
+                    int rc = queue_trypop(&p->frame_queue, &item);
+                    if (rc <= 0) break;
+                    p->held_frame = (DecodedFrame *)item;
+                }
+            }
+            break;
+        }
 
         if (next_due != INT64_MAX) {
             int64_t sl = next_due - now_us();

--- a/src/vdec.c
+++ b/src/vdec.c
@@ -267,6 +267,43 @@ static int feed_packet(VdecContext *ctx, int buf_idx, AVPacket *pkt)
 }
 
 /* ------------------------------------------------------------------ */
+/* Send a zero-length EOS packet to signal end-of-stream to the HW    */
+/* decoder, causing it to flush its internal pipeline.                 */
+/* ------------------------------------------------------------------ */
+
+static int send_eos_packet(VdecContext *ctx, int *out_buf_free)
+{
+    for (int i = 0; i < VDEC_OUTPUT_BUFS; i++) {
+        if (!out_buf_free[i]) continue;
+
+        struct v4l2_buffer buf;
+        struct v4l2_plane  plane;
+        memset(&buf,   0, sizeof(buf));
+        memset(&plane, 0, sizeof(plane));
+
+        buf.type        = V4L2_BUF_TYPE_VIDEO_OUTPUT_MPLANE;
+        buf.memory      = V4L2_MEMORY_MMAP;
+        buf.index       = (uint32_t)i;
+        buf.m.planes    = &plane;
+        buf.length      = 1;
+        plane.bytesused = 0;                  /* zero-length = EOS signal */
+        plane.length    = ctx->out_buf_size;
+
+        if (xioctl(ctx->fd, VIDIOC_QBUF, &buf) < 0) {
+            perror("vdec: VIDIOC_QBUF EOS");
+            return -1;
+        }
+
+        out_buf_free[i] = 0;
+        vlog("vdec: EOS packet queued on output buf %d\n", i);
+        return 0;
+    }
+
+    /* No free buffer available yet — caller should retry next iteration */
+    return 1;
+}
+
+/* ------------------------------------------------------------------ */
 /* Public API                                                           */
 /* ------------------------------------------------------------------ */
 
@@ -448,21 +485,24 @@ int vdec_open(VdecContext *ctx, AVStream *stream,
 
 /* ------------------------------------------------------------------ */
 
+#define VDEC_DRAIN_STALL_SECONDS 10
+ 
 void vdec_run(VdecContext *ctx)
 {
     int out_buf_free[VDEC_OUTPUT_BUFS];
     for (int i = 0; i < VDEC_OUTPUT_BUFS; i++)
         out_buf_free[i] = 1;
-
-    int eos       = 0;
-    int eos_polls = 0;
-    int sps_timing = 0;
-    struct timespec sps_start = {0};
-
+ 
+    int eos            = 0;
+    int drain_cmd_sent = 0;
+    int sps_timing     = 0;
+    struct timespec sps_start   = {0};
+    struct timespec last_output = {0};
+ 
     struct pollfd pfd;
     pfd.fd     = ctx->fd;
     pfd.events = POLLIN | POLLPRI;
-
+ 
     while (1) {
         /* Reclaim OUTPUT buffers */
         {
@@ -479,45 +519,39 @@ void vdec_run(VdecContext *ctx)
                 out_buf_free[buf.index] = 1;
             }
         }
-
-        /* Feed packets */
+ 
+        /* Feed packets.
+         * NOTE: there is deliberately NO "if (queue->closed) discard" branch
+         * here. queue_pop() drains buffered items first and only returns 0
+         * once the queue is closed AND empty, so this loop feeds the entire
+         * tail to the hardware and sets eos only when nothing is left. */
         if (!eos) {
             for (int i = 0; i < VDEC_OUTPUT_BUFS; i++) {
                 if (!out_buf_free[i]) continue;
-
+ 
                 void *item = NULL;
-
-                /* If queue is closed free all items */
-                if (ctx->packet_queue->closed) {
-                    while (!queue_pop(ctx->packet_queue, &item)) {
-                        AVPacket *pkt = (AVPacket *)item;
-                        av_packet_free(&pkt);
-                    }
-                    eos = 1;
-		    break;
-                }
-
                 if (!queue_pop(ctx->packet_queue, &item)) {
-                    eos = 1;
+                    eos = 1;            /* closed and drained */
                     break;
                 }
                 AVPacket *raw_pkt = (AVPacket *)item;
-
+ 
+ 
                 if (ctx->bsf) {
                     if (av_bsf_send_packet(ctx->bsf, raw_pkt) < 0) {
                         av_packet_free(&raw_pkt);
                         continue;
                     }
                     av_packet_free(&raw_pkt);
-
+ 
                     AVPacket *out_pkt = av_packet_alloc();
                     if (!out_pkt) continue;
-
+ 
                     if (av_bsf_receive_packet(ctx->bsf, out_pkt) < 0) {
                         av_packet_free(&out_pkt);
                         continue;
                     }
-
+ 
                     out_buf_free[i] = 0;
                     int err = feed_packet(ctx, i, out_pkt);
                     av_packet_free(&out_pkt);
@@ -530,7 +564,22 @@ void vdec_run(VdecContext *ctx)
                 }
             }
         }
-
+ 
+        /* Input exhausted — trigger the hardware drain exactly once.
+         * V4L2_DEC_CMD_STOP tells bcm2835 no more input is coming, so it
+         * should flush its pipeline and eventually mark the final CAPTURE
+         * buffer with V4L2_BUF_FLAG_LAST. */
+        if (eos && !drain_cmd_sent) {
+            struct v4l2_decoder_cmd cmd;
+            memset(&cmd, 0, sizeof(cmd));
+            cmd.cmd = V4L2_DEC_CMD_STOP;
+            if (xioctl(ctx->fd, VIDIOC_DECODER_CMD, &cmd) < 0)
+                perror("vdec: VIDIOC_DECODER_CMD STOP");
+            drain_cmd_sent = 1;
+            clock_gettime(CLOCK_MONOTONIC, &last_output);
+            vlog("vdec: input drained — sent DECODER_CMD STOP, draining\n");
+        }
+ 
         /* Poll */
         int ret = poll(&pfd, 1, 100);
         if (ret < 0) {
@@ -538,7 +587,7 @@ void vdec_run(VdecContext *ctx)
             perror("vdec: poll");
             break;
         }
-
+ 
         /* Handle SOURCE_CHANGE */
         if (pfd.revents & POLLPRI) {
             struct v4l2_event evt;
@@ -553,7 +602,7 @@ void vdec_run(VdecContext *ctx)
                 }
             }
         }
-
+ 
         /* Dequeue decoded frames */
         if ((pfd.revents & POLLIN) && ctx->fmt_negotiated) {
             while (1) {
@@ -565,57 +614,81 @@ void vdec_run(VdecContext *ctx)
                 buf.memory   = V4L2_MEMORY_MMAP;
                 buf.m.planes = &plane;
                 buf.length   = 1;
-
+ 
                 if (xioctl(ctx->fd, VIDIOC_DQBUF, &buf) < 0) break;
+ 
+                int is_last = (buf.flags & V4L2_BUF_FLAG_LAST) != 0;
+ 
+                if (plane.bytesused > 0) {
+                    DecodedFrame *frame = malloc(sizeof(DecodedFrame));
+                    if (!frame) {
+                        xioctl(ctx->fd, VIDIOC_QBUF, &buf);
+                    } else {
+                        frame->dmabuf_fd  = ctx->cap_dmabuf_fd[buf.index];
+                        frame->buf_index  = (int)buf.index;
+                        frame->width      = ctx->stream_width;
+                        frame->stride     = ctx->stride;
+                        frame->height     = ctx->height;
+                        frame->src_height = ctx->orig_height;
+                        frame->sar_num    = ctx->sar_num;
+                        frame->sar_den    = ctx->sar_den;
+                        frame->pts_us     = (int64_t)buf.timestamp.tv_sec * 1000000LL
+                                          + (int64_t)buf.timestamp.tv_usec;
+ 
 
-                DecodedFrame *frame = malloc(sizeof(DecodedFrame));
-                if (!frame) {
-                    xioctl(ctx->fd, VIDIOC_QBUF, &buf);
-                    continue;
-                }
-
-                frame->dmabuf_fd  = ctx->cap_dmabuf_fd[buf.index];
-                frame->buf_index  = (int)buf.index;
-                frame->width      = ctx->stream_width;   /* visible width */
-                frame->stride     = ctx->stride;          /* bytesperline from driver */
-                frame->height     = ctx->height;
-                frame->src_height = ctx->orig_height;
-                frame->sar_num    = ctx->sar_num;
-                frame->sar_den    = ctx->sar_den;
-                frame->pts_us     = (int64_t)buf.timestamp.tv_sec  * 1000000LL
-                                  + (int64_t)buf.timestamp.tv_usec;
-
-                /* Block while ahead of audio */
-                if (ctx->audio_pts) {
-                    int64_t video_pts = frame->pts_us;
-
-                    double delta;
-                    int first_iter = 1;
-                    do {
-                        delta = -(*ctx->audio_pts * ctx->audio_time_base - video_pts * ctx->video_time_base);
-
-                        if (first_iter) {
-                            first_iter = 0;
-                            if (delta < VIDEO_AUDIO_DESYNC_THRESHOLD_MAX) break;
+ 
+                        /* Block while ahead of audio (separate-audio path only) */
+                        if (ctx->audio_pts) {
+                            int64_t video_pts = frame->pts_us;
+                            double delta;
+                            int first_iter = 1;
+                            do {
+                                delta = -(*ctx->audio_pts * ctx->audio_time_base
+                                          - video_pts * ctx->video_time_base);
+                                if (first_iter) {
+                                    first_iter = 0;
+                                    if (delta < VIDEO_AUDIO_DESYNC_THRESHOLD_MAX) break;
+                                }
+                                usleep(VIDEO_AUDIO_DESYNC_EPSILON * 1000000.0);
+                            } while (!ctx->packet_queue->closed &&
+                                     (delta > VIDEO_AUDIO_DESYNC_THRESHOLD_MIN));
                         }
-
-                        usleep(VIDEO_AUDIO_DESYNC_EPSILON * 1000000.0);
-                    } while (!ctx->packet_queue->closed && (delta > VIDEO_AUDIO_DESYNC_THRESHOLD_MIN));
+ 
+                        if (!queue_push(ctx->frame_queue, frame)) {
+                            free(frame);
+                            goto done;
+                        }
+                    }
+                } else {
+                    /* Empty buffer (may be the drain's end-of-stream marker
+                     * with no image payload) — just recycle it. */
+                    xioctl(ctx->fd, VIDIOC_QBUF, &buf);
                 }
-
-                if (!queue_push(ctx->frame_queue, frame)) {
-                    free(frame);
+ 
+                clock_gettime(CLOCK_MONOTONIC, &last_output);
+ 
+                if (is_last) {
+                    vlog("vdec: V4L2_BUF_FLAG_LAST — hardware fully drained\n");
                     goto done;
                 }
             }
         }
-
-        if (eos) {
-            if (++eos_polls > 3) break;
+ 
+        /* Drain safety net: if we've asked the hardware to stop and it has
+         * produced nothing for VDEC_DRAIN_STALL_SECONDS, give up rather than
+         * spin forever (covers firmware that never sets BUF_FLAG_LAST). */
+        if (drain_cmd_sent) {
+            struct timespec now;
+            clock_gettime(CLOCK_MONOTONIC, &now);
+            if ((now.tv_sec - last_output.tv_sec) >= VDEC_DRAIN_STALL_SECONDS) {
+                fprintf(stderr, "vdec: drain stalled (%ds, no LAST flag) — exiting\n",
+                        VDEC_DRAIN_STALL_SECONDS);
+                break;
+            }
         }
-
-        /* If SOURCE_CHANGE never arrives after 10 real seconds, the
-         * hardware can't decode this stream — bail out cleanly. */
+ 
+        /* If SOURCE_CHANGE never arrives after 10 real seconds, the hardware
+         * can't decode this stream — bail out cleanly. */
         if (!ctx->fmt_negotiated) {
             struct timespec now;
             clock_gettime(CLOCK_MONOTONIC, &now);
@@ -630,7 +703,7 @@ void vdec_run(VdecContext *ctx)
             sps_timing = 0;
         }
     }
-
+ 
 done:
     queue_close(ctx->frame_queue);
 }


### PR DESCRIPTION
Fix: videos exiting 2–3 seconds early
Summary
Playback ended a couple of seconds before the true end of file, the final frames were decoded-or-decodable but never displayed. Reproducible with Big Buck Bunny (the closing shot was getting cut off).

Root cause
Two separate bugs stacked on top of each other, which is why partial fixes appeared to do nothing, each one masked the other.

The packet tail was being discarded before it reached the decoder. When the demuxer hit EOF and closed the video packet queue, the feed loop in vdec_run took a "queue closed → drain and free remaining items" branch that abandoned every buffered packet still sitting in the queue (the decoder runs behind the demuxer, so that backlog is the last few seconds of video). Those packets were never fed to the hardware. queue_pop() already has correct drain-on-close semantics - it returns buffered items until the queue is both closed and empty, so the branch was pure data loss.
The decoder pipeline wasn't being drained at end-of-stream. Even once the tail was fed, vdec exited on a fixed poll-count timeout before the hardware had emitted its buffered frames (bcm2835 decodes at roughly display rate, so several seconds can be in flight at EOF).

Changes

Removed the discard branch in the vdec_run feed loop; the normal queue_pop() path now feeds the entire buffered tail and only sets EOS once the queue is closed and drained.
Replaced the fixed timeout with a proper V4L2 stateful-decoder drain: once input is exhausted, send V4L2_DEC_CMD_STOP, then keep dequeuing CAPTURE buffers until one comes back with V4L2_BUF_FLAG_LAST. A wall-clock no-progress guard remains as a safety net for firmware that never sets the flag.
As a side effect this also fixes the minor end-of-playback A/V desync, since video now plays its full tail instead of dying ~3s before the audio.

Testing
Played multiple files to the actual end on a Pi (audio/video stay in sync through the final frame). Long seeks still exit cleanly.
Known follow-up (not in this PR)
On single-core hardware (Pi Zero 1), rapid short seeks can still freeze the player, this is pre-existing seek-churn behavior (full pipeline teardown + hardware flush per keypress), not introduced here. Planned fix is to debounce/coalesce seeks.