### PR TITLE
fix: choose device supporting atomic commits on raspi 4

### DIFF
--- a/src/drm.c
+++ b/src/drm.c
@@ -901,18 +901,26 @@ int drm_open(DrmContext *ctx)
         if (!(devices[i]->available_nodes & (1 << DRM_NODE_PRIMARY)))
             continue;
         ctx->fd = open(devices[i]->nodes[DRM_NODE_PRIMARY], O_RDWR | O_CLOEXEC);
-        if (ctx->fd >= 0) break;
+
+        if(ctx->fd < 0){
+            vlog("drm: failed to open %s : %s\n", devices[i]->nodes[DRM_NODE_PRIMARY], strerror(errno));
+            continue;
+        }
+
+        if (drmSetClientCap(ctx->fd, DRM_CLIENT_CAP_ATOMIC, 1) == 0)
+            break;
+        else{
+            close(ctx->fd);
+            ctx->fd = -1;
+        }
     }
     drmFreeDevices(devices, device_count);
 
     if (ctx->fd < 0) {
-        fprintf(stderr, "drm: no suitable DRM device found\n");
+        fprintf(stderr, "drm: no DRM device with atomic mode setting found\n");
         return -1;
     }
 
-    if (drmSetClientCap(ctx->fd, DRM_CLIENT_CAP_ATOMIC, 1) < 0) {
-        fprintf(stderr, "drm: no atomic\n"); return -1;
-    }
     if (drmSetClientCap(ctx->fd, DRM_CLIENT_CAP_UNIVERSAL_PLANES, 1) < 0) {
         fprintf(stderr, "drm: no universal planes\n"); return -1;
     }


### PR DESCRIPTION
On Raspberry Pi 4, there are 2 video-devices (0 and 1). Only one supports atomic commits.

**Problem:** on every restart the kernel may map the 2 video-devices differently to card0 and card1. So drmGetDevices2() sometimes returns the device first which does not support atomic commits. In this case, I get the error "drm: no atomics", because the for-loop exits after the first found device.

**Proposed solution:** move the check if the device supports atomic commits inside the device-loop.